### PR TITLE
[takea-look#16] Android 아키텍쳐 따르도록 auth 모듈 구조 변경

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.takealook.spring.convention)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/core/data/src/main/kotlin/com/takealook/data/UserEntity.kt
+++ b/core/data/src/main/kotlin/com/takealook/data/UserEntity.kt
@@ -1,10 +1,10 @@
-package com.takealook.login
+package com.takealook.data
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 
 @Table("users")
-data class AuthInfo(
+data class UserEntity(
     @Id
     val id: Long? = null,
     val username: String,

--- a/core/data/src/main/kotlin/com/takealook/data/UserRepository.kt
+++ b/core/data/src/main/kotlin/com/takealook/data/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.takealook.data
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface UserRepository : CoroutineCrudRepository<UserEntity, Long> {
+    suspend fun findByUsername(username: String): UserEntity?
+}

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.takealook.spring.convention)
+}
+
+dependencies {
+    implementation(projects.core.data)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/core/domain/src/main/kotlin/com/takealook/domain/GetUserByIdUseCase.kt
+++ b/core/domain/src/main/kotlin/com/takealook/domain/GetUserByIdUseCase.kt
@@ -1,0 +1,13 @@
+package com.takealook.domain
+
+import com.takealook.data.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class GetUserByIdUseCase(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(id: Long): User? = repository
+        .findById(id)
+        ?.toUser()
+}

--- a/core/domain/src/main/kotlin/com/takealook/domain/GetUserByNameUseCase.kt
+++ b/core/domain/src/main/kotlin/com/takealook/domain/GetUserByNameUseCase.kt
@@ -1,0 +1,13 @@
+package com.takealook.domain
+
+import com.takealook.data.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class GetUserByNameUseCase(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(username: String): User? = repository
+        .findByUsername(username)
+        ?.toUser()
+}

--- a/core/domain/src/main/kotlin/com/takealook/domain/SaveUserUseCase.kt
+++ b/core/domain/src/main/kotlin/com/takealook/domain/SaveUserUseCase.kt
@@ -1,0 +1,13 @@
+package com.takealook.domain
+
+import com.takealook.data.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SaveUserUseCase(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(user: User): User = repository
+        .save(user.toUserEntity())
+        .toUser()
+}

--- a/core/domain/src/main/kotlin/com/takealook/domain/User.kt
+++ b/core/domain/src/main/kotlin/com/takealook/domain/User.kt
@@ -1,0 +1,22 @@
+package com.takealook.domain
+
+import com.takealook.data.UserEntity
+
+data class User(
+    val id: Long? = null,
+    val username: String,
+    val password: String,
+)
+
+fun UserEntity.toUser() = User(
+    id = id,
+    username = username,
+    password = password
+)
+
+fun User.toUserEntity() = UserEntity(
+    id = this.id,
+    username = username,
+    password = this.password
+)
+

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -8,6 +8,8 @@ group = "my.takealook"
 version = "0.0.1"
 
 dependencies {
+    implementation(projects.core.domain)
+
     implementation(libs.spring.boot.starter.security)
     implementation(libs.jjwt.api)
     runtimeOnly(libs.jjwt.impl)

--- a/feature/auth/src/main/kotlin/com/takealook/auth/AuthController.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/AuthController.kt
@@ -1,10 +1,13 @@
-package com.takealook.login
+package com.takealook.auth
 
-import com.takealook.login.component.JwtTokenProvider
-import com.takealook.login.exception.InvalidCredentialsException
-import com.takealook.login.exception.UserAlreadyExistsException
-import com.takealook.login.model.LoginRequest
-import com.takealook.login.model.LoginResponse
+import com.takealook.domain.GetUserByNameUseCase
+import com.takealook.domain.SaveUserUseCase
+import com.takealook.domain.User
+import com.takealook.auth.component.JwtTokenProvider
+import com.takealook.auth.exception.InvalidCredentialsException
+import com.takealook.auth.exception.UserAlreadyExistsException
+import com.takealook.auth.model.LoginRequest
+import com.takealook.auth.model.LoginResponse
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -14,14 +17,16 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/auth")
 class AuthController(
-    private val userRepository: AuthRepository,
+    private val getUserByNameUseCase: GetUserByNameUseCase,
+    private val saveUserUseCase: SaveUserUseCase,
     private val passwordEncoder: PasswordEncoder,
     private val jwtTokenProvider: JwtTokenProvider
 ) {
 
     @PostMapping("/signin")
     suspend fun login(@RequestBody loginRequest: LoginRequest): LoginResponse {
-        val user = userRepository.findByUsername(loginRequest.username)
+        println("request : $loginRequest")
+        val user = getUserByNameUseCase(loginRequest.username)
             ?: throw InvalidCredentialsException("Invalid username or password")
 
         if (!passwordEncoder.matches(loginRequest.password, user.password)) {
@@ -34,14 +39,15 @@ class AuthController(
 
     @PostMapping("/signup")
     suspend fun signUp(@RequestBody signupRequest: LoginRequest): Unit {
-        if (userRepository.findByUsername(signupRequest.username) != null) {
+        if (getUserByNameUseCase(signupRequest.username) != null) {
             throw UserAlreadyExistsException("Username '${signupRequest.username}' is already taken.")
         }
 
-        val user = AuthInfo(
+        val user = User(
             username = signupRequest.username,
             password = passwordEncoder.encode(signupRequest.password)
         )
-        userRepository.save(user)
+
+        saveUserUseCase(user)
     }
 }

--- a/feature/auth/src/main/kotlin/com/takealook/auth/component/JwtTokenProvider.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/component/JwtTokenProvider.kt
@@ -1,4 +1,4 @@
-package com.takealook.login.component
+package com.takealook.auth.component
 
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys

--- a/feature/auth/src/main/kotlin/com/takealook/auth/configuration/SecurityConfig.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/configuration/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package com.takealook.login.configuration
+package com.takealook.auth.configuration
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/feature/auth/src/main/kotlin/com/takealook/auth/exception/GlobalExceptionHandler.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/exception/GlobalExceptionHandler.kt
@@ -1,4 +1,4 @@
-package com.takealook.login.exception
+package com.takealook.auth.exception
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/feature/auth/src/main/kotlin/com/takealook/auth/exception/InvalidCredentialsException.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/exception/InvalidCredentialsException.kt
@@ -1,3 +1,3 @@
-package com.takealook.login.exception
+package com.takealook.auth.exception
 
 class InvalidCredentialsException(message: String) : RuntimeException(message)

--- a/feature/auth/src/main/kotlin/com/takealook/auth/exception/UserAlreadyExistsException.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/exception/UserAlreadyExistsException.kt
@@ -1,3 +1,3 @@
-package com.takealook.login.exception
+package com.takealook.auth.exception
 
 class UserAlreadyExistsException(message: String) : RuntimeException(message)

--- a/feature/auth/src/main/kotlin/com/takealook/auth/model/LoginResponse.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/auth/model/LoginResponse.kt
@@ -1,4 +1,4 @@
-package com.takealook.login.model
+package com.takealook.auth.model
 
 data class LoginResponse(
     val accessToken: String

--- a/feature/auth/src/main/kotlin/com/takealook/login/AuthRepository.kt
+++ b/feature/auth/src/main/kotlin/com/takealook/login/AuthRepository.kt
@@ -1,7 +1,0 @@
-package com.takealook.login
-
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
-
-interface AuthRepository : CoroutineCrudRepository<AuthInfo, Long> {
-    suspend fun findByUsername(username: String): AuthInfo?
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,12 @@ dependencyResolutionManagement {
 
 
 include(":app")
+
+// Core
+include(":core:data")
+include(":core:domain")
+
+// Feature
 include(":feature:stickers")
 include(":feature:auth")
 


### PR DESCRIPTION
## OverView
Spring Project를 **Android App Architecture** 를 따르도록 수정했다.

기존에는 Clean Architecture 를 따르려는 시도를 해보았다.
> presentation -> domain <- data 

이럴 경우 몇가지 문제점이 생겨서 철회하게 되었다.

## Clean Architecture 구현기
domain 레이어는 원칙상, **Framework 와는 독립적으로 동작**해야한다. (의존성 주입을 위해 Bean을 사용해야하는 점은 논외로 두었다.)
그렇기에 Domain Layer에는 Repository에 대한 interface를 두기로 결정했다. 

그러나 고려해야할 점은,  이 Repository Interface는 Spring 의 R2DBC Repository 인터페이스를 상속받아서 Spring 시스템이 구현체를 자동 생성하도록 유도해야한다.

```kotlin
import org.springframework.data.repository.kotlin.CoroutineCrudRepository // <- spring ㅠ

interface UserR2dbcRepository : CoroutineCrudRepository<UserEntity, Long>
```

해당 코드는 Spring 에 의존성이 있으므로,  data 레이어로 가야 적합하다. 
대신, domain에는 별도의 Repository를 두고 data 레이어에서 이를 구현하도록 설계를 했다.
```kotlin
// :domain

interface UserRepository
```
```kotlin
// :data

@Repository
class DefaultUserRepository(
    private val repository : UserR2dbcRepository
) : UserRepository
```
이를 기반으로 domain에 useCase까지 구현하였다.
```kotlin
@Component
class GetUserByNameUseCase(
    private val repository : UserRepository
) { ... }
```
### 문제 인식
이제 Feature 모듈에서 이 domain만을 의존하여 RestController를 완성시키면 된다...만,
막상 연결 후 실행해보니 다음과 같은 에러가 던져졌다.

```
Parameter 0 of constructor in com.takealook.login.AuthController required a bean of type 'com.takealook.domain.UserRepository' that could not be found.
```

대충 **UserRepository 구현체를 주입시켜줄 수 없다**는 내용이다. 그러나 이미 data 클래스에 구현체는 만들어놓았을 터.

Feature가 domain을 바라보지만, **막상 domain은 data 모듈에 대해서 전혀 모른다**.
알아보니 Feature 모듈 입장에서는 **data 모듈에 정의해놓은 구현체의 classPath가 런타임에 포함되어있지않다** 는 내용이었다.

이를 해결하려면 Feature 모듈에 data, domain을 모두 적용시켜줘야한다고한다. 
그러나 이는 멀티모듈의 장점과, 클린 아키텍쳐 방향성과도 멀어지기 때문에 이 방법을 선택할 수 없었다.


## 나의 Android App Architecture 를 알까?
> 의존방향은 presentation(feature) -> domain -> data 이다. 

우선 앞선 클린아키텍쳐 기반으로 작성했을 때의 문제점을 해결하기 위해서는, 단방향 의존성으로 설계하여 모든 모듈의 classPath 를 포함할 수 있도록 설계하여야한다.

그러기 위해서 Feature -> Domain -> Data 로 의존방향이 되는 아키텍쳐를 고민해야했다.
응? 잠깐 어디서 많이 보았다. 

<img width="1725" height="1005" alt="image" src="https://github.com/user-attachments/assets/71e6dc8f-c96a-456f-b801-38d1d0fde371" />
(익숙하다면 당신은 안드개발자)

이렇게 의존방향으로 설계했을 시, Domain은 Data를 직접적으로 바라보게 되면서 구현체에 대한 의존성(Bean)을 정상적으로 생성할 수 있었다. 


